### PR TITLE
DOC: Remove the letter 's' from "InitialTransformParametersFileName"

### DIFF
--- a/manual.tex
+++ b/manual.tex
@@ -1506,7 +1506,7 @@ image region).
 The transform parameter file can be manually edited or created as
 is convenient for the user. Multiple transformations are composed
 by iteratively supplying another transform parameter file with the
-\texttt{InitialTransformParametersFileName} tag. The last
+\texttt{InitialTransformParameterFileName} tag. The last
 transformation will be the one where the initial transform
 parameter file name is set to \texttt{"NoInitialTransform"}.
 
@@ -3299,7 +3299,7 @@ Also for \texttt{for}-loops.
 (Transform "EulerTransform")
 (NumberOfParameters 3)
 (TransformParameters -0.000000 -4.564513 -2.091174)
-(InitialTransformParametersFileName "NoInitialTransform")
+(InitialTransformParameterFileName "NoInitialTransform")
 (HowToCombineTransforms "Compose")
 
 // Image specific


### PR DESCRIPTION
Follow-up to pull request https://github.com/SuperElastix/elastix/pull/903 commit https://github.com/SuperElastix/elastix/commit/2170592cbd018cce65698d404cae281f40c28d39

Addresses issue https://github.com/SuperElastix/elastix/issues/900, "InitialTransformParametersFileName or InitialTransformParameterFileName? (with or without letter 's')"